### PR TITLE
Try to make a junction if user doesn't have permissions for symlinks

### DIFF
--- a/lygadgets/salt_linker.py
+++ b/lygadgets/salt_linker.py
@@ -20,7 +20,8 @@ def symlink_windows(source, destination):
     try:
         os.symlink(source, destination)
         return
-    except (AttributeError, OSError):
+    # except (AttributeError, OSError):
+    except AttributeError:
         pass
 
     # Command line shell
@@ -29,12 +30,16 @@ def symlink_windows(source, destination):
         assert retval == 0
         return
     except (subprocess.CalledProcessError, WindowsError, AssertionError):
-        try:
-            retval = subprocess.check_call(f"mklink /J {destination} {source}", shell=True)
-            assert retval == 0
-            return
-        except (subprocess.CalledProcessError, WindowsError, AssertionError):
-            pass
+        pass
+        # try:
+        #     # Creating a junction only works with directories
+        #     if not is_pymodule(source):
+        #         retval = subprocess.check_call(f"mklink /J {destination} {source}", shell=True)
+        #         assert retval == 0
+        #     return
+        # except (subprocess.CalledProcessError, WindowsError, AssertionError) as err:
+        #     print(err)
+        #     pass
 
     # Big magic with windows-specific package
     # From https://stackoverflow.com/questions/1447575/symlinks-on-windows

--- a/lygadgets/salt_linker.py
+++ b/lygadgets/salt_linker.py
@@ -20,7 +20,7 @@ def symlink_windows(source, destination):
     try:
         os.symlink(source, destination)
         return
-    except AttributeError:
+    except (AttributeError, OSError):
         pass
 
     # Command line shell
@@ -29,7 +29,12 @@ def symlink_windows(source, destination):
         assert retval == 0
         return
     except (subprocess.CalledProcessError, WindowsError, AssertionError):
-        pass
+        try:
+            retval = subprocess.check_call(f"mklink /J {destination} {source}", shell=True)
+            assert retval == 0
+            return
+        except (subprocess.CalledProcessError, WindowsError, AssertionError):
+            pass
 
     # Big magic with windows-specific package
     # From https://stackoverflow.com/questions/1447575/symlinks-on-windows

--- a/lygadgets/salt_linker.py
+++ b/lygadgets/salt_linker.py
@@ -20,8 +20,7 @@ def symlink_windows(source, destination):
     try:
         os.symlink(source, destination)
         return
-    # except (AttributeError, OSError):
-    except AttributeError:
+    except (AttributeError, OSError):
         pass
 
     # Command line shell
@@ -30,16 +29,15 @@ def symlink_windows(source, destination):
         assert retval == 0
         return
     except (subprocess.CalledProcessError, WindowsError, AssertionError):
-        pass
-        # try:
-        #     # Creating a junction only works with directories
-        #     if not is_pymodule(source):
-        #         retval = subprocess.check_call(f"mklink /J {destination} {source}", shell=True)
-        #         assert retval == 0
-        #     return
-        # except (subprocess.CalledProcessError, WindowsError, AssertionError) as err:
-        #     print(err)
-        #     pass
+        try:
+            # Creating a junction only works with directories
+            if not is_pymodule(source):
+                retval = subprocess.check_call(f"mklink /J {destination} {source}", shell=True)
+                assert retval == 0
+            return
+        except (subprocess.CalledProcessError, WindowsError, AssertionError) as err:
+            print(err)
+            pass
 
     # Big magic with windows-specific package
     # From https://stackoverflow.com/questions/1447575/symlinks-on-windows


### PR DESCRIPTION
Linking can generate an error (_OSError: [WinError 1314] A required privilege is not held by the client_) when the user doesn't have administrator privileges. This change creates a junction instead, so the package doesn't require these privileges.